### PR TITLE
Update factorial in calculator.js

### DIFF
--- a/calculator/calculator.js
+++ b/calculator/calculator.js
@@ -21,7 +21,6 @@ function power(a, b) {
 }
 
 function factorial(n) {
-  if (n == 0) return 1;
   let product = 1;
   for (let i = n; i > 0; i--) {
     product *= i;


### PR DESCRIPTION
We dont need to return 1 if n = 0 because we set the return value (product) to 1 at the first line in the function so it can not be 0.
If you did this for visual reasons thats fine i just wanted to say that.