### PR TITLE
Update Leap Year Definition and grammar

### DIFF
--- a/leapYears/README.md
+++ b/leapYears/README.md
@@ -2,7 +2,7 @@
 
 Create a function that determines whether or not a given year is a leap year.  Leap years are determined by the following rules:
 
->There is a leap year every year whose number is perfectly divisible by four - except for years which are both divisible by 100 and not divisible by 400. The second part of the rule effects century years. For example; the century years 1600 and 2000 are leap years, but the century years 1700, 1800, and 1900 are not.
+>There is a leap year every year whose number is perfectly divisible by four - except for years evenly divisible by 100, which are not leap years unless evenly divisible by 400. The second part of the rule affects century years. For example; the century years 1600 and 2000 are leap years, but the century years 1700, 1800, and 1900 are not.
 
 ```javascript
 leapYears(2000) // is a leap year: returns true


### PR DESCRIPTION
I got confused after seeing the code in solution that definition and solution didn't match so this is what I found on Wikipedia "(except for years evenly divisible by 100, which are not leap years unless evenly divisible by 400)" but earlier it was written here "except for years which are both divisible by 100 and not divisible by 400." 

I maybe wrong here, not knowing that these two statements maybe are indicating two different things, if that's the case, then feel free to not apply the changes and do let me know. 😄 

P.S. - I corrected "effects" to "affects" too.