### PR TITLE
helloWorld.spec.js: Fix disparity between the README example and spec file

### DIFF
--- a/helloWorld/helloWorld.spec.js
+++ b/helloWorld/helloWorld.spec.js
@@ -1,5 +1,7 @@
 const helloWorld = require('./helloWorld');
 
-test('says "Hello, World!"', function() {
-  expect(helloWorld()).toBe("Hello, World!");
+describe('Hello World', function() {
+  test('says "Hello, World!"', function() {
+    expect(helloWorld()).toBe('Hello, World!');
+  });
 });

--- a/helloWorld/helloWorld.spec.js
+++ b/helloWorld/helloWorld.spec.js
@@ -2,6 +2,6 @@ const helloWorld = require('./helloWorld');
 
 describe('Hello World', function() {
   test('says "Hello, World!"', function() {
-    expect(helloWorld()).toBe('Hello, World!');
+    expect(helloWorld()).toEqual('Hello, World!');
   });
 });


### PR DESCRIPTION
Quick fix to bring the actual spec file in line with the example in the README.