### PR TITLE
fix 'says hello world' in README.md

### DIFF
--- a/01_helloWorld/README.md
+++ b/01_helloWorld/README.md
@@ -13,7 +13,7 @@ Let's look at the spec file first:
 const helloWorld = require('./helloWorld');
 
 describe('Hello World', function() {
-  test('says hello world', function() {
+  test('says "Hello, World!"', function() {
     expect(helloWorld()).toEqual('Hello, World!');
   });
 });


### PR DESCRIPTION
change `'says hello world'`  to   `'says "Hello, World!" '` to be identical to the code in the (helloWorld.spec.js) file.