### PR TITLE
Add a test case for the multiply function

### DIFF
--- a/08_calculator/calculator.spec.js
+++ b/08_calculator/calculator.spec.js
@@ -39,6 +39,9 @@ describe('sum', () => {
 });
 
 describe('multiply', () => {
+	test.skip('multiplies an empty array', () => {
+		expect(calculator.multiply([])).toBe(0);
+	});
 	test.skip('multiplies two numbers', () => {
 		expect(calculator.multiply([2,4])).toBe(8);
 	});


### PR DESCRIPTION
My original solution would incorrectly return `1` for an empty array, but it passes all the current tests.
```javascript
const multiply = function(operands) {
  return operands.reduce((total, operand) => total *= operand, 1);
};
```
New test checks that multiply function returns `0` for an empty array.