### PR TITLE
Update NPM instruction to new lesson link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ There will eventually be a suggested order of completion, but at this time since
 
 ## How To Use These Exercises
 Before you start you should have a few things installed on your machine:
-1. **NPM**. To check if you have NPM installed, type `npm --version` in your terminal. If you get back `Command 'npm' not found, but can be installed with:`, do NOT follow the instructions in the terminal to install with `apt-get`. (This causes permission issues.) Instead, install Node with NVM by following the instructions [here](https://github.com/TheOdinProject/curriculum/blob/master/foundations/installations/installing_node.md).
+1. **NPM**. We should have installed NPM already in [this Installing Node.js lesson](https://www.theodinproject.com/paths/foundations/courses/foundations/lessons/installing-node-js). Just in case you need to check, type `npm --version` in your terminal. If you get back `Command 'npm' not found, but can be installed with:`, do NOT follow the instructions in the terminal to install with `apt-get`. (This causes permission issues.) Instead, go back to the installation lesson and install Node with NVM by following the instructions there.
 2. **A copy of this repository**. Copies of repositories on your machine are called clones. If you need help cloning, you can learn how [here](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository).
 3. **Jest**. After cloning this repository to your local machine, go into the newly created directory (`cd javascript-exercises`) and run `npm install`. This will install Jest and set up the testing platform based on our preconfigured settings.
 


### PR DESCRIPTION
This PR is the third task of [#23248](https://github.com/TheOdinProject/curriculum/issues/23248)

The new Node.js installation instructions have been merged into the main TOP site and are now located [here](https://www.theodinproject.com/paths/foundations/courses/foundations/lessons/installing-node-js).

This PR updates the README to reflect the change.