### PR TITLE
Fix palindromes false positive test

### DIFF
--- a/09_palindromes/palindromes.spec.js
+++ b/09_palindromes/palindromes.spec.js
@@ -17,6 +17,6 @@ describe('palindromes', () => {
     expect(palindromes('Animal loots foliated detail of stool lamina.')).toBe(true);
   });
   test.skip('doesn\'t just always return true', () => {
-    expect(palindromes('ZZZZ car, a man, a maraca.')).toBe(false);
+    expect(palindromes('ZZZZ car, a man, a maracaz.')).toBe(false);
   });
 });


### PR DESCRIPTION
As all palindromes have the exact same first and last letter, people only had to test for first and last letter equallity, and the only test where it should return false, it has the first and last letters being different. to pass the whole test people only had to test for first and last letter weither they are equal or not, which make mistakes like this pass the test : 

```js
const palindromes = function (input) {
  let str = input.replace(/[^0-9a-z]/gi, "").toLowerCase();
  for (var i in str) {
    if (str[i] != str[str.length-1-i]) {
      return false;
    }
    return true;
  }
};
```

this mistake happens to a lot of people, where they return true inside rather than outside the loop. I myself did this mistake many times.

My change will make sure that the first and last letter of a none-palindrome sentence the same, which returns true if people only tested first and last letter. passing the tests now require people to do the palindrome test properly.