### PR TITLE
Templates: Create PR and Issue files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug Report
+about: Create a report to help us improve
+title: ''
+labels: 'Status: Needs Review, Type: Bug'
+assignees: ''
+
+---
+<!-- Thank you for taking the time to submit a bug report to The Odin Project. In order to get issues closed in a reasonable amount of time, you must include a baseline of information about the bug in question. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->
+
+<!-- Complete the following REQUIRED checkboxes by replacing the whitespace between the square brackets with an 'x', e.g. [x]. -->
+- [ ] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
+- [ ] The title of this issue follows the `where the change occurs: brief description of bug` format, e.g. `React section: Knowledge Checks don't link to resource`
+
+<!-- The following checkbox is OPTIONAL. Completing it does not guarantee you will be assigned this issue, but rather lets us know you are interested in working on it. -->
+- [ ] I would like to be assigned this issue to work on it
+
+**1. Description of the Bug**
+<!-- A clear and concise description of what the bug is. Include any screenshots that may help show the bug in action. -->
+
+
+**2. How To Reproduce**
+<!-- What steps one might need to take in order to reproduce this bug. -->
+
+
+**3. Expected Behavior**
+<!-- A brief description of what you expected to happen. -->
+
+
+**4. Desktop/Device:**
+ - Device: <!-- [e.g. iPhone6] -->
+ - OS: <!-- [e.g. iOS] -->
+ - Browser: <!-- [e.g. chrome, safari] -->
+ - Version: <!-- [e.g. 22] -->
+
+**5. Additional Information**
+<!-- Any additional information about the bug. -->
+

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,38 +1,54 @@
 ---
 name: Bug Report
-about: Create a report to help us improve
-title: ''
-labels: 'Status: Needs Review, Type: Bug'
-assignees: ''
-
+about: Create a report to help us improve something that is not working correctly
+title: "Bug - :"
+labels: "Status: Needs Review, Type: Bug"
+assignees: ""
 ---
+
 <!-- Thank you for taking the time to submit a bug report to The Odin Project. In order to get issues closed in a reasonable amount of time, you must include a baseline of information about the bug in question. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->
 
-<!-- Complete the following REQUIRED checkboxes by replacing the whitespace between the square brackets with an 'x', e.g. [x]. -->
-- [ ] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-- [ ] The title of this issue follows the `where the change occurs: brief description of bug` format, e.g. `React section: Knowledge Checks don't link to resource`
+Complete the following REQUIRED checkboxes:
+-   [ ] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
+-   [ ] The title of this issue follows the `Bug - location of bug: brief description of bug` format, e.g. `Bug - Exercises: File type incorrect for all test files`
 
-<!-- The following checkbox is OPTIONAL. Completing it does not guarantee you will be assigned this issue, but rather lets us know you are interested in working on it. -->
-- [ ] I would like to be assigned this issue to work on it
+The following checkbox is OPTIONAL:
+<!-- Completing this checkbox does not guarantee you will be assigned this issue, but rather lets us know you are interested in working on it. -->
+-   [ ] I would like to be assigned this issue to work on it
 
-**1. Description of the Bug**
+<hr>
+
+**1. Description of the Bug:**
 <!-- A clear and concise description of what the bug is. Include any screenshots that may help show the bug in action. -->
 
 
-**2. How To Reproduce**
-<!-- What steps one might need to take in order to reproduce this bug. -->
+**2. How To Reproduce:**
+<!--
+What steps one might need to take in order to reproduce this bug, e.g.:
+1. Log in
+2. Visit a lesson page
+3. Click the complete button
+4. The complete button does not update
+-->
 
 
-**3. Expected Behavior**
-<!-- A brief description of what you expected to happen. -->
+**3. Expected Behavior:**
+<!--
+A brief description of what you expected to happen, e.g.:
+1. Log in
+2. Visit a lesson page
+3. Click the complete button
+4. The complete button updates correctly
+ -->
 
 
 **4. Desktop/Device:**
- - Device: <!-- [e.g. iPhone6] -->
- - OS: <!-- [e.g. iOS] -->
- - Browser: <!-- [e.g. chrome, safari] -->
- - Version: <!-- [e.g. 22] -->
+<!-- The more information you are able to provide, the better. -->
+-   Device: <!-- [e.g. iPhone6] -->
+-   OS: <!-- [e.g. iOS] -->
+-   Browser: <!-- [e.g. chrome, safari] -->
+-   Version: <!-- [e.g. 22] -->
 
-**5. Additional Information**
+**5. Additional Information:**
 <!-- Any additional information about the bug. -->
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: Feature Request
+about: Suggest a new feature or enhancement for this project 
+title: ''
+labels: 'Status: Needs Review'
+assignees: ''
+
+---
+<!-- Thank you for taking the time to submit a new feature request to The Odin Project. In order to get issues closed in a reasonable amount of time, you must include a baseline of information about the feature/enhancement you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->
+
+<!-- Complete the following REQUIRED checkboxes by replacing the whitespace between the square brackets with an 'x', e.g. [x]. -->
+- [ ] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
+- [ ] The title of this issue follows the `where the change occurs: brief description of request` format, e.g. `Global SCSS file: Buttons should have XYZ`
+
+<!-- The following checkbox is OPTIONAL. Completing it does not guarantee you will be assigned this issue, but rather lets us know you are interested in working on it. -->
+- [ ] I would like to be assigned this issue to work on it
+
+**1. Description of the Feature Request**
+<!-- A clear and concise description of what the feature is. Also include how it would be useful/beneficial or what problem(s) it would solve. -->
+
+
+**2. Additional Information**
+<!-- Any additional information or screenshots about the feature request. -->
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,24 +1,38 @@
 ---
 name: Feature Request
-about: Suggest a new feature or enhancement for this project 
-title: ''
-labels: 'Status: Needs Review'
-assignees: ''
-
+about: Suggest a new feature or enhancement for this project
+title: ""
+labels: "Status: Needs Review"
+assignees: ""
 ---
+
 <!-- Thank you for taking the time to submit a new feature request to The Odin Project. In order to get issues closed in a reasonable amount of time, you must include a baseline of information about the feature/enhancement you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->
 
-<!-- Complete the following REQUIRED checkboxes by replacing the whitespace between the square brackets with an 'x', e.g. [x]. -->
-- [ ] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-- [ ] The title of this issue follows the `where the change occurs: brief description of request` format, e.g. `Global SCSS file: Buttons should have XYZ`
+Complete the following REQUIRED checkboxes:
+-   [ ] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
+-   [ ] The title of this issue follows the `location for request: brief description of request` format, e.g. `Exercises: Add exercise on XYZ`
 
-<!-- The following checkbox is OPTIONAL. Completing it does not guarantee you will be assigned this issue, but rather lets us know you are interested in working on it. -->
-- [ ] I would like to be assigned this issue to work on it
+The following checkbox is OPTIONAL:
+<!-- Completing this checkbox does not guarantee you will be assigned this issue, but rather lets us know you are interested in working on it. -->
+-   [ ] I would like to be assigned this issue to work on it
 
-**1. Description of the Feature Request**
-<!-- A clear and concise description of what the feature is. Also include how it would be useful/beneficial or what problem(s) it would solve. -->
+<hr>
+
+**1. Description of the Feature Request:**
+<!-- 
+A clear and concise description of what the feature or enhancement is, including how it would be useful/beneficial or what problem(s) it would solve. 
+-->
 
 
-**2. Additional Information**
-<!-- Any additional information or screenshots about the feature request. -->
+**2. Acceptance Criteria:**
+<!--
+A list of checkbox items that explain the requirements needed to be met to resolve this request, e.g.:
+- [ ] A theme toggle is present on the dashboard
+- [ ] Clicking the theme toggle changes between light and dark
+- [ ] A user's theme choice persists after leaving the website
+ -->
+
+
+**3. Additional Information:**
+<!-- Any additional information about the feature request, such as a link to a Discord discussion, screenshots, etc. -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+<!-- Thank you for taking the time to contribute to The Odin Project. In order to get pull requests (PRs) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->
+
+<!-- Complete the following REQUIRED checkboxes by replacing the whitespace between the square brackets with an 'x', e.g. [x]. -->
+- [ ] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
+- [ ] The title of this PR follows the `where the change occurs: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
+
+<!-- Complete the following checkboxes ONLY IF they are applicable to your PR. You can complete these later if they are not currently applicable. -->
+- [ ] If one exists, I have linked a related open issue to this PR in Step 2 below
+- [ ] If changes were requested, I have made them and re-requested a review from the maintainer (top of the right sidebar)
+
+**1. Description of the Changes**
+<!-- A clear and concise description of your changes. If this PR is not related to an open issue also include why you are proposing these changes, such as what benefits the changes have or what problem(s) they solve. --> 
+
+
+**2. Related Issue**
+<!-- If the PR is not related to any open issue, skip this step. 
+
+Otherwise, replace the XXXXX with the issue number, e.g. Closes #2013, or if the issue is in another TOP repo replace #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX -->
+Closes #XXXXX

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,19 +1,30 @@
-<!-- Thank you for taking the time to contribute to The Odin Project. In order to get pull requests (PRs) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->
+<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->
 
-<!-- Complete the following REQUIRED checkboxes by replacing the whitespace between the square brackets with an 'x', e.g. [x]. -->
-- [ ] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-- [ ] The title of this PR follows the `where the change occurs: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
+Complete the following REQUIRED checkboxes:
+<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
+-   [ ] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
+-   [ ] The title of this PR follows the `location of change: brief description of change` format, e.g. `01_helloWorld: Update test cases`
 
-<!-- Complete the following checkboxes ONLY IF they are applicable to your PR. You can complete these later if they are not currently applicable. -->
-- [ ] If one exists, I have linked a related open issue to this PR in Step 2 below
-- [ ] If changes were requested, I have made them and re-requested a review from the maintainer (top of the right sidebar)
+Complete the following checkboxes ONLY IF they are applicable to your PR. You can complete them later if they are not currently applicable:
+-   [ ] I have ensured any exercise files included in this PR have passed all of their tests
 
-**1. Description of the Changes**
-<!-- A clear and concise description of your changes. If this PR is not related to an open issue also include why you are proposing these changes, such as what benefits the changes have or what problem(s) they solve. --> 
+<hr>
 
+**1. Because:**
+<!--
+If this PR closes an open issue, replace the XXXXX below with the issue number, e.g. Closes #2013. Or if the issue is in another TOP repo replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX
 
-**2. Related Issue**
-<!-- If the PR is not related to any open issue, skip this step. 
-
-Otherwise, replace the XXXXX with the issue number, e.g. Closes #2013, or if the issue is in another TOP repo replace #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX -->
+Otherwise, provide a clear and concise reason for your pull request, e.g. what problem it solves or what benefit it provides. If this PR is related to, but does not close, another issue or PR, you can also link it as above without the 'Closes' keyword, e.g. "Related to #2013".
+ -->
 Closes #XXXXX
+
+
+**2. This PR:**
+<!--
+A bullet point list of one or more items outlining what was done in this PR to solve the problem(s) or implement the feature/enhancement.
+ -->
+
+
+**3. Additional Information:**
+<!-- Any additional information about the PR, such as a link to a Discord discussion, etc. -->
+


### PR DESCRIPTION
I have created PR and Issue templates to be inline with our other repos, specifically our main TOP repo (with variations to better fit the purposes of this repo).