### PR TITLE
Remove irrelevant text from README about order of completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,9 @@
 These are a series of JavaScript exercises intended to be used alongside the curriculum at 'The Odin Project'. They start simple and easy but get more complex and involved as you progress through them.
 
-There will eventually be a suggested order of completion, but at this time since we are still in the process of creating more exercises the order is subject to change and has not yet been specified. However, there are a few exercises that make a good "starting point". Feel free to at least start with these:
-
-1. Hello World
-2. Repeat String
-3. Reverse String
-
 ## How To Use These Exercises
+
 Before you start you should have a few things installed on your machine:
+
 1. **NPM**. We should have installed NPM already in [this Installing Node.js lesson](https://www.theodinproject.com/paths/foundations/courses/foundations/lessons/installing-node-js). Just in case you need to check, type `npm --version` in your terminal. If you get back `Command 'npm' not found, but can be installed with:`, do NOT follow the instructions in the terminal to install with `apt-get`. (This causes permission issues.) Instead, go back to the installation lesson and install Node with NVM by following the instructions there.
 2. **A copy of this repository**. Copies of repositories on your machine are called clones. If you need help cloning, you can learn how [here](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository).
 3. **Jest**. After cloning this repository to your local machine, go into the newly created directory (`cd javascript-exercises`) and run `npm install`. This will install Jest and set up the testing platform based on our preconfigured settings.
@@ -19,6 +15,7 @@ Each exercise includes 3 files: a markdown file with a description of the task, 
 The first exercise, `helloWorld`, will walk you through the process in-depth.
 
 ## Debugging
+
 To debug functions, you can run the tests in the Visual Studio Code debugger terminal. You can open this by clicking the "Run and Debug" icon on the left or pressing `ctrl + shift + D`, then clicking JavaScript Debug Terminal. You will be able to set breakpoints as you would in the Chrome DevTools debugger. You can run `npm test exerciseName.spec.js` to then execute your code up until your breakpoint and step through your code as necessary. **NOTE**: To take advantage of the debugger, you **MUST** run the script in the debugger terminal, not the bash or zsh terminal.
 
 ## Solutions


### PR DESCRIPTION
This change is in relation to [this PR](https://github.com/TheOdinProject/curriculum/pull/23588). Both PRs aim to improve the organization and clarity of the Foundations>JavaScript Basics>Fundamentals Part 4 lesson.

The overarching goal is to dramatically reduce the number of learners that skip the necessary set-up steps for the TDD exercises.