### PR TITLE
removeFromArray: Change function arguments

### DIFF
--- a/removeFromArray/removeFromArray.js
+++ b/removeFromArray/removeFromArray.js
@@ -1,9 +1,9 @@
 // we have 2 solutions here, an easier one and a more advanced one.
 // The easiest way to get an array of all of the arguments that are passed to a function
 // is using the rest operator. If this is unfamiliar to you look it up!
-const removeFromArray = function (...args) {
+const removeFromArray = function (array, ...args) {
   // the very first item in our list of arguments is the array, we pull it out with args[0]
-  const array = args[0];
+  // const array = args[0];
   // create a new empty array
   const newArray = [];
   // use forEach to go through the array


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->

Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `01_helloWorld: Update test cases`

Complete the following checkboxes ONLY IF they are applicable to your PR. You can complete them later if they are not currently applicable:
-   [x] I have ensured any exercise files included in this PR have passed all of their tests

<hr>

**1. Because:**
<!--
If this PR closes an open issue, replace the XXXXX below with the issue number, e.g. Closes #2013. Or if the issue is in another TOP repo replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

Otherwise, provide a clear and concise reason for your pull request, e.g. what problem it solves or what benefit it provides. If this PR is related to, but does not close, another issue or PR, you can also link it as above without the 'Closes' keyword, e.g. "Related to #2013".
 -->
As per current definition,
within the forEach loop, the array itself (being an element of args) is checked for includes('item'), leading to one additional comparison.

However, it doesn't lead to error as item will never be the array itself. 

**2. This PR:**
<!--
A bullet point list of one or more items outlining what was done in this PR to solve the problem(s) or implement the feature/enhancement.
 -->
- By splitting the arguments as changes, the additional comparison is avoided.
- Commented out line 6 since it will cause error as per new definition.



**3. Additional Information:**
<!-- Any additional information about the PR, such as a link to a Discord discussion, etc. -->

