### PR TITLE
07_tempConversion: Update tempConversion function's naming

### DIFF
--- a/07_tempConversion/README.md
+++ b/07_tempConversion/README.md
@@ -2,12 +2,12 @@
 
 Write two functions that convert temperatures from Fahrenheit to Celsius, and vice versa:
 ```
-ftoc(32) // fahrenheit to celsius, should return 0
+convertToCelsius(32) // fahrenheit to celsius, should return 0
 
-ctof(0) // celsius to fahrenheit, should return 32
+convertToFahrenheit(0) // celsius to fahrenheit, should return 32
 ```
 
-Because we are human, we want the result temperature to be rounded to one decimal place: i.e., `ftoc(100)` should return `37.8` and not `37.77777777777778`.
+Because we are human, we want the result temperature to be rounded to one decimal place: i.e., `convertToCelsius(100)` should return `37.8` and not `37.77777777777778`.
 
 This exercise asks you to create more than one function so the `module.exports` section of the spec file looks a little different this time.  Nothing to worry about, we're just packaging both functions into a single object to be exported.
 

--- a/07_tempConversion/tempConversion.js
+++ b/07_tempConversion/tempConversion.js
@@ -1,13 +1,11 @@
-const ftoc = function() {
-
+const convertToCelsius = function() {
 };
 
-const ctof = function() {
-
+const convertToFahrenheit = function() {
 };
 
 // Do not edit below this line
 module.exports = {
-  ftoc,
-  ctof
+  convertToCelsius,
+  convertToFahrenheit
 };

--- a/07_tempConversion/tempConversion.spec.js
+++ b/07_tempConversion/tempConversion.spec.js
@@ -4,22 +4,22 @@ describe('convertToCelsius', () => {
   test('works', () => {
     expect(convertToCelsius(32)).toEqual(0);
   });
-  test('rounds to 1 decimal', () => {
+  test.skip('rounds to 1 decimal', () => {
     expect(convertToCelsius(100)).toEqual(37.8);
   });
-  test('works with negatives', () => {
+  test.skip('works with negatives', () => {
     expect(convertToCelsius(-100)).toEqual(-73.3);
   });
 });
 
 describe('convertToFahrenheit', () => {
-  test('works', () => {
+  test.skip('works', () => {
     expect(convertToFahrenheit(0)).toEqual(32);
   });
-  test('rounds to 1 decimal', () => {
+  test.skip('rounds to 1 decimal', () => {
     expect(convertToFahrenheit(73.2)).toEqual(163.8);
   });
-  test('works with negatives', () => {
+  test.skip('works with negatives', () => {
     expect(convertToFahrenheit(-10)).toEqual(14);
   });
 });

--- a/07_tempConversion/tempConversion.spec.js
+++ b/07_tempConversion/tempConversion.spec.js
@@ -1,25 +1,25 @@
-const {ftoc, ctof} = require('./tempConversion')
+const {convertToCelsius, convertToFahrenheit} = require('./tempConversion')
 
-describe('ftoc', () => {
+describe('convertToCelsius', () => {
   test('works', () => {
-    expect(ftoc(32)).toEqual(0);
+    expect(convertToCelsius(32)).toEqual(0);
   });
-  test.skip('rounds to 1 decimal', () => {
-    expect(ftoc(100)).toEqual(37.8);
+  test('rounds to 1 decimal', () => {
+    expect(convertToCelsius(100)).toEqual(37.8);
   });
-  test.skip('works with negatives', () => {
-    expect(ftoc(-100)).toEqual(-73.3);
+  test('works with negatives', () => {
+    expect(convertToCelsius(-100)).toEqual(-73.3);
   });
 });
 
-describe('ctof', () => {
-  test.skip('works', () => {
-    expect(ctof(0)).toEqual(32);
+describe('convertToFahrenheit', () => {
+  test('works', () => {
+    expect(convertToFahrenheit(0)).toEqual(32);
   });
-  test.skip('rounds to 1 decimal', () => {
-    expect(ctof(73.2)).toEqual(163.8);
+  test('rounds to 1 decimal', () => {
+    expect(convertToFahrenheit(73.2)).toEqual(163.8);
   });
-  test.skip('works with negatives', () => {
-    expect(ctof(-10)).toEqual(14);
+  test('works with negatives', () => {
+    expect(convertToFahrenheit(-10)).toEqual(14);
   });
 });


### PR DESCRIPTION
## Because
The current function names in tempConversion are unreadable and directly contradict eveything stated about writing clean code two lesson earlier this PR updates them to be more inline 


## This PR
* Changes the function names to be more in line with the convention recommended in the clean code lesson
* Updates README.md and tempConversion.spec.js to account for these changes


## Related to
* #300

## Additional Information
Discussed in https://discord.com/channels/505093832157691914/1041022385123491840. While there was some valid reasoning that the convention we lay forth in the clean code isn't always used nor always the standard convention, I saw no real opposition to the specific issue of updating these names.


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `01_helloWorld: Update test cases`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR includes changes that needs to be updated on the `solutions` branch, I have created another PR (and linked it to this PR).
