### PR TITLE
12_findTheOldest: Clarify test descriptions

### DIFF
--- a/12_findTheOldest/findTheOldest.spec.js
+++ b/12_findTheOldest/findTheOldest.spec.js
@@ -1,7 +1,7 @@
 const findTheOldest = require('./findTheOldest')
 
 describe('findTheOldest', () => {
-  test('finds the oldest person!', () => {
+  test('finds the person with the greatest age!', () => {
     const people = [
       {
         name: "Carly",
@@ -21,7 +21,7 @@ describe('findTheOldest', () => {
     ]
     expect(findTheOldest(people).name).toBe('Ray');
   });
-  test.skip('finds the oldest person if someone is still living', () => {
+  test.skip('finds the person with the greatest age if someone is still living', () => {
     const people = [
       {
         name: "Carly",
@@ -40,7 +40,7 @@ describe('findTheOldest', () => {
     ]
     expect(findTheOldest(people).name).toBe('Ray');
   });
-  test.skip('finds the oldest person if the OLDEST is still living', () => {
+  test.skip('finds the person with the greatest age if the OLDEST is still living', () => {
     const people = [
       {
         name: "Carly",


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
The tests for 12_findTheOldest lead to frequent confusion because of the disconnect between the English sentence in the test description, and the expected outcome of the test. 

The confusion comes from expectations of how we use English. Culturally in English speaking countries (i can't speak for others), we are not used to referring to anyone who is already dead as the oldest. When 2 people are dead, and someone is alive and 17 years old, that person is generally thought about as "the oldest", because oldest is reserved for the living. 

Culturally, the second test: *'finds the person with the greatest age if someone is still living'* would be considered ambiguous English. That's the test that causes the most confusion.

Additionally, the test passing arguments are too similar to the function itself. 

The `findTheOldest()` pass condition is 'finds the oldest person!'

To make this less ambiguous and less tautological, I suggest changing 
`'the oldest person'` 
to 
`the person with the greatest age`

I believe this helps with some of the common tendency to infer that the person who is living is older than the person who is dead, no matter how old the dead person was when they were alive.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
* Made changes to all three test descriptions to replace `oldest person` to `person with the greatest age`.


## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #XXXXX

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->
[Link to a recent discussion](https://discord.com/channels/505093832157691914/514204569572605952/1093679446130700339) where many people expressed confusion while solving this exercise.
Here are some more examples of people getting caught up on understanding the wording.
* [here](https://discord.com/channels/505093832157691914/690590001486102589/985970491082821673)
* [here](https://discord.com/channels/505093832157691914/513125308757442562/1079457625726525611)
* [here](https://discord.com/channels/505093832157691914/690590001486102589/1011249663564853258)
* [here](https://discord.com/channels/505093832157691914/505093832157691916/987136185157709825)
* [here](https://discord.com/channels/505093832157691914/690590001486102589/950144431439380480)

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `01_helloWorld: Update test cases`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If this PR includes changes that needs to be updated on the `solutions` branch, I have created another PR (and linked it to this PR).
