### PR TITLE
Fix issue with returning incorrect value for string inputs

### DIFF
--- a/10_fibonacci/solution/fibonacci-solution.js
+++ b/10_fibonacci/solution/fibonacci-solution.js
@@ -1,5 +1,6 @@
 const fibonacci = function (count) {
-  if (count < 0) return "OOPS";
+  count = Number(count);
+  if (isNaN(count) || count < 0) return "OOPS";
   if (count === 0) return 0;
   let a = 0;
   let b = 1;


### PR DESCRIPTION
Issue Fix #192 

I fixed the issue in the fibonacci function where it was returning 1 instead of 0 for string inputs that represent the number 0. I did this by adding a line of code that converts the input to a number and then checking if it's NaN or less than 0. This change should make the function work correctly for both number inputs and string inputs that represent valid numbers.