### PR TITLE
Fix: change requirement to reflect solutions change

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,4 +29,4 @@ Closes #XXXXX
 -   [ ] The `Because` section summarizes the reason for this PR
 -   [ ] The `This PR` section has a bullet point list describing the changes in this PR
 -   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
--   [ ] If this PR includes changes that needs to be updated on the `solutions` branch, I have created another PR (and linked it to this PR).
+-   [ ] If this PR includes any changes that affect the solution of an exercise, I've also updated the solution in the `/solutions` folder 


### PR DESCRIPTION
## Because
- We've moved from a `solutions` branch to `/solution` folders


## This PR
- Updates the Pull Request template to reflect this change


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `01_helloWorld: Update test cases`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR