### PR TITLE
Repo README: Improve wording regarding TOP provided solution

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you have a suggestion to improve an exercise, an idea for a new exercise, or 
 4. Some of the exercises have test conditions defined in their spec file as `test.skip` compared to `test`. This is purposeful. After you pass one `test`, you will change the next `test.skip` to `test` and test your code again. You'll do this until all conditions are satisfied. **All tests must pass at the same time**, and you should not have any `test.skip` instances by the time you finish an exercise.
 5. Once you successfully finish an exercise, check the `solutions` directory within each exercise to compare it with yours.
    - You should not be checking the solution for an exercise until you finish it!
-   - If your solution differs wildly from TOP's solution (and still passes the self-check criteria), that's completely fine. Do feel free to ask about it in the chatroom if there are parts you do not understand.
+   - If your solution differs wildly from TOP's solution (and still passes the exercise's requirements), that's completely fine. Do feel free to ask about it in our Discord if there are parts you do not understand.
 6. Do not submit your solutions to this repo, as any PRs that do so will be closed without merging.
 
 **Note**: Due to the way Jest handles failed tests, it may return an exit code of 1 if any tests fail. NPM will interpret this as an error and you may see some `npm ERR!` messages after Jest runs. You can ignore these, or run your test with `npm test exerciseName.spec.js --silent` to supress the errors.

--- a/README.md
+++ b/README.md
@@ -13,21 +13,21 @@ If you have a suggestion to improve an exercise, an idea for a new exercise, or 
 
 1. Fork and clone this repository. To learn how to fork a repository, see the GitHub documentation on how to [fork a repo](https://docs.github.com/en/get-started/quickstart/fork-a-repo).
    - Copies of repositories on your machine are called clones. If you need help cloning to your local environment you can learn how from the GitHub documentation on [cloning a repository](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository-from-github/cloning-a-repository).
-2. Before you start working on any exercises, you should first ensure you have the following installed:
+1. Before you start working on any exercises, you should first ensure you have the following installed:
    - **NPM**. You should have installed NPM already in our [Installing Node.js](https://www.theodinproject.com/paths/foundations/courses/foundations/lessons/installing-node-js) lesson. Just in case you need to check, type `npm --version` in your terminal. If you get back `Command 'npm' not found, but can be installed with:`, **do not follow the instructions in the terminal** to install with `apt-get` as this causes permission issues. Instead, go back to the installation lesson and install Node with NVM by following the instructions there.
    - **Jest**. After cloning this repository to your local machine and installing NPM, go into the newly created directory (`cd javascript-exercises`) and run `npm install`. This will install Jest and set up the testing platform based on our preconfigured settings. (Note: if you get warnings that packages are out of date or contain vulnerabilities, you can safely ignore them for these exercises.)
 
-3. Each exercise includes the following:
+1. Each exercise includes the following:
 
    - A markdown file with a description of the task, an empty (or mostly empty) JavaScript file, and a set of tests.
    - A `solutions` directory that contains a solution and the same test file with all of the tests unskipped.
 
    To complete an exercise, you'll need to go to the exercise directory with `cd exerciseName` in the terminal and run `npm test exerciseName.spec.js`. This should run the test file and show you the output. When you first run a test, it will fail. This is by design! You must open the exercise file and write the code needed to get the test to pass.
-4. Some of the exercises have test conditions defined in their spec file as `test.skip` compared to `test`. This is purposeful. After you pass one `test`, you will change the next `test.skip` to `test` and test your code again. You'll do this until all conditions are satisfied. **All tests must pass at the same time**, and you should not have any `test.skip` instances by the time you finish an exercise.
-5. Once you successfully finish an exercise, check the `solutions` directory within each exercise to compare it with yours.
+1. Some of the exercises have test conditions defined in their spec file as `test.skip` compared to `test`. This is purposeful. After you pass one `test`, you will change the next `test.skip` to `test` and test your code again. You'll do this until all conditions are satisfied. **All tests must pass at the same time**, and you should not have any `test.skip` instances by the time you finish an exercise.
+1. Once you successfully finish an exercise, check the `solutions` directory within each exercise to compare it with yours.
    - You should not be checking the solution for an exercise until you finish it!
    - If your solution differs wildly from TOP's solution (and still passes the exercise's requirements), that's completely fine. Do feel free to ask about it in our Discord if there are parts you do not understand.
-6. Do not submit your solutions to this repo, as any PRs that do so will be closed without merging.
+1. Do not submit your solutions to this repo, as any PRs that do so will be closed without merging.
 
 **Note**: Due to the way Jest handles failed tests, it may return an exit code of 1 if any tests fail. NPM will interpret this as an error and you may see some `npm ERR!` messages after Jest runs. You can ignore these, or run your test with `npm test exerciseName.spec.js --silent` to supress the errors.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you have a suggestion to improve an exercise, an idea for a new exercise, or 
 2. Before you start working on any exercises, you should first ensure you have the following installed:
    - **NPM**. You should have installed NPM already in our [Installing Node.js](https://www.theodinproject.com/paths/foundations/courses/foundations/lessons/installing-node-js) lesson. Just in case you need to check, type `npm --version` in your terminal. If you get back `Command 'npm' not found, but can be installed with:`, **do not follow the instructions in the terminal** to install with `apt-get` as this causes permission issues. Instead, go back to the installation lesson and install Node with NVM by following the instructions there.
    - **Jest**. After cloning this repository to your local machine and installing NPM, go into the newly created directory (`cd javascript-exercises`) and run `npm install`. This will install Jest and set up the testing platform based on our preconfigured settings. (Note: if you get warnings that packages are out of date or contain vulnerabilities, you can safely ignore them for these exercises.)
-   
+
 3. Each exercise includes the following:
 
    - A markdown file with a description of the task, an empty (or mostly empty) JavaScript file, and a set of tests.
@@ -26,7 +26,7 @@ If you have a suggestion to improve an exercise, an idea for a new exercise, or 
 4. Some of the exercises have test conditions defined in their spec file as `test.skip` compared to `test`. This is purposeful. After you pass one `test`, you will change the next `test.skip` to `test` and test your code again. You'll do this until all conditions are satisfied. **All tests must pass at the same time**, and you should not have any `test.skip` instances by the time you finish an exercise.
 5. Once you successfully finish an exercise, check the `solutions` directory within each exercise to compare it with yours.
    - You should not be checking the solution for an exercise until you finish it!
-   - Keep in mind that TOP's solution is not the only solution. Generally as long as all of the tests pass, your solution should be fine.
+   - If your solution differs wildly from TOP's solution (and still passes the self-check criteria), that's completely fine. Do feel free to ask about it in the chatroom if there are parts you do not understand.
 6. Do not submit your solutions to this repo, as any PRs that do so will be closed without merging.
 
 **Note**: Due to the way Jest handles failed tests, it may return an exit code of 1 if any tests fail. NPM will interpret this as an error and you may see some `npm ERR!` messages after Jest runs. You can ignore these, or run your test with `npm test exerciseName.spec.js --silent` to supress the errors.


### PR DESCRIPTION
## Because
People are very commonly concerned when they see their exercise solutions differ from the provided solutions. This is primarily from two parts:
- Learners are initially directed straight to the relevant exercise directory and not told to read the repo README (where a note about the provided solution is). *This has been addressed in [#27055](https://github.com/TheOdinProject/curriculum/pull/27055)*
- The README note on provided solutions, despite saying the provided one isn't the only solution, the rest of the sentence seems to be interpret-able as "if your solution differs, check with the community if it's actually allowed".


## This PR
- Improves the wording of the relevant README note to clarify intent (unified wording with `css-exercises` repo)


## Issue
Closes [#27053](https://github.com/TheOdinProject/curriculum/issues/27053)

## Additional Information
In conjunction with [#463](https://github.com/TheOdinProject/css-exercises/pull/463) from the `css-exercises` repo


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `01-flex-center: Update self check`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, I have ensured that the TOP solution files match the Desired Outcome image
