### PR TITLE
12_findTheOldest fix ambiguity and remove redundant test description

### DIFF
--- a/12_findTheOldest/findTheOldest.spec.js
+++ b/12_findTheOldest/findTheOldest.spec.js
@@ -21,26 +21,7 @@ describe('findTheOldest', () => {
     ]
     expect(findTheOldest(people).name).toBe('Ray');
   });
-  test.skip('finds the person with the greatest age if someone is still living', () => {
-    const people = [
-      {
-        name: "Carly",
-        yearOfBirth: 2018,
-      },
-      {
-        name: "Ray",
-        yearOfBirth: 1962,
-        yearOfDeath: 2011,
-      },
-      {
-        name: "Jane",
-        yearOfBirth: 1912,
-        yearOfDeath: 1941,
-      },
-    ]
-    expect(findTheOldest(people).name).toBe('Ray');
-  });
-  test.skip('finds the person with the greatest age if the OLDEST is still living', () => {
+  test('finds the oldest person if yearOfDeath field is not present', () => {
     const people = [
       {
         name: "Carly",

--- a/12_findTheOldest/findTheOldest.spec.js
+++ b/12_findTheOldest/findTheOldest.spec.js
@@ -21,7 +21,26 @@ describe('findTheOldest', () => {
     ]
     expect(findTheOldest(people).name).toBe('Ray');
   });
-  test('finds the oldest person if yearOfDeath field is not present', () => {
+  test.skip('finds the oldest person if yearOfDeath field is undefined on a non-oldest person', () => {
+    const people = [
+      {
+        name: "Carly",
+        yearOfBirth: 2018,
+      },
+      {
+        name: "Ray",
+        yearOfBirth: 1962,
+        yearOfDeath: 2011,
+      },
+      {
+        name: "Jane",
+        yearOfBirth: 1912,
+        yearOfDeath: 1941,
+      },
+    ]
+    expect(findTheOldest(people).name).toBe('Ray');
+  });
+  test.skip('finds the oldest person if yearOfDeath field is undefined for the oldest person', () => {
     const people = [
       {
         name: "Carly",


### PR DESCRIPTION
fix ambiguity in test description , old was 'finds the person with the greatest age if someone is still living.'
remove redundant test that checks for 'finds the person with the greatest age if the OLDEST is still living' since both this and the above test for ability to check if there is no death year field.

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
I had faced difficulty understanding the tests so wanted to make it easier for others to understand the test when they are learning


## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->

- Remove one of the three tests as I think it is redundant
- Modify the test description of the last test to make it more concise


## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #XXXXX

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `01_helloWorld: Update test cases`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If this PR includes any changes that affect the solution of an exercise, I've also updated the solution in the `/solutions` folder 
