### PR TITLE
09_palindromes: Replace regex solution with non-regex version

### DIFF
--- a/09_palindromes/solution/palindromes-solution.js
+++ b/09_palindromes/solution/palindromes-solution.js
@@ -1,6 +1,19 @@
 const palindromes = function (string) {
-  const processedString = string.toLowerCase().replace(/[^a-z0-9]/g, "");
-  return processedString.split("").reverse().join("") == processedString;
+  // Since we only consider letters and numbers, create a variable containing all valid characters
+  let alphanumerical = 'abcdefghijklmnopqrstuvwxyz0123456789';
+
+  // Convert to lowercase, split to array of individual characters, filter only valid characters, then rejoin as new string
+  const cleanedString = string
+    .toLowerCase()
+    .split('')
+    .filter((character) => alphanumerical.includes(character))
+    .join('');
+
+  // Create a new reversed string for comparison
+  const reversedString = cleanedString.split('').reverse().join('');
+
+  // Return the outcome of the comparison which will either be true or false
+  return cleanedString === reversedString;
 };
 
 module.exports = palindromes;


### PR DESCRIPTION
## Because
#319 replaced the regex solution for the palindromes exercise with a non-regex solution, which definitely was the right move given the context of the curriculum at that point as well as regular gripes in the community from learners who get hit in the face with a regex brick wall upon seeing the solution. However, this was only reflected in the `solutions` branch and not in the `main` branch.
Since then, changes to the `main` branch's solutions test file have not been reflected in the `solutions` branch and it seems this branch is no longer in use/being updated; learners are also unlikely to be aware of this branch and will just use the solutions directory from the `main` branch.

## This PR
- Replaces the `main` branch `09_palindromes` regex-based solution with the non-regex solution from the `solutions` branch.
- Adapts that solution to the current test suite, which accounts for unevenly spaced numbers which the original did not pass.
- Cleaned formatting of comments and improved their wording for clarity.


## Issue
N/A

## Additional Information
<details>
  <summary>Proof that the new solution passes all current tests in the main branch:</summary>

![Palindromes non-regex solution and test results](https://i.ibb.co/tP5ymgy/20240229-185732-screenshot.jpg)

</details>



## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `01_helloWorld: Update test cases`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If this PR includes any changes that affect the solution of an exercise, I've also updated the solution in the `/solutions` folder 
