### PR TITLE
09_palindromes: Use const for solution variable

### DIFF
--- a/09_palindromes/solution/palindromes-solution.js
+++ b/09_palindromes/solution/palindromes-solution.js
@@ -1,6 +1,6 @@
 const palindromes = function (string) {
   // Since we only consider letters and numbers, create a variable containing all valid characters
-  let alphanumerical = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  const alphanumerical = 'abcdefghijklmnopqrstuvwxyz0123456789';
 
   // Convert to lowercase, split to array of individual characters, filter only valid characters, then rejoin as new string
   const cleanedString = string


### PR DESCRIPTION
## Because
One of the variables uses `let` as a carryover from the original solution adapted from.
This variable is never reassigned, so would be better declared with `const`.
A tiny pedantic change but since the rest of the function's non-reassigned variables are declared with `const`, this keeps things consistent and prevents any "why use let here and const there?" confusions from learners.


## This PR
- Changes a non-reassigned variable to be declared via `const` instead of `let` 


## Issue
N/A

## Additional Information


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `01_helloWorld: Update test cases`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If this PR includes any changes that affect the solution of an exercise, I've also updated the solution in the `/solutions` folder 
