### PR TITLE
New exercise | Pascal

### DIFF
--- a/19_pascal/README.md
+++ b/19_pascal/README.md
@@ -1,0 +1,3 @@
+# Exercise 17 - pascal
+
+Description of the exercise goes here.

--- a/19_pascal/pascal.js
+++ b/19_pascal/pascal.js
@@ -1,0 +1,6 @@
+const pascal = function() {
+  
+};
+  
+// Do not edit below this line
+module.exports = pascal;

--- a/19_pascal/pascal.spec.js
+++ b/19_pascal/pascal.spec.js
@@ -1,0 +1,15 @@
+const pascal = require('./pascal');
+
+describe('pascal', () => {
+  test('First test description', () => {
+    // Replace this comment with any other necessary code, and update the expect line as necessary
+
+    expect(pascal()).toBe('');
+  });
+  
+  test.skip('Second test description', () => {
+    // Replace this comment with any other necessary code, and update the expect line as necessary
+
+    expect(pascal()).toBe('');
+  });
+});

--- a/19_pascal/solution/pascal-solution.js
+++ b/19_pascal/solution/pascal-solution.js
@@ -1,0 +1,6 @@
+const pascal = function() {
+  // Replace this comment with the solution code
+};
+  
+// Do not edit below this line
+module.exports = pascal;

--- a/19_pascal/solution/pascal-solution.spec.js
+++ b/19_pascal/solution/pascal-solution.spec.js
@@ -1,0 +1,15 @@
+const pascal = require('./pascal-solution');
+
+describe('pascal', () => {
+  test('First test description', () => {
+    // Replace this comment with any other necessary code, and update the expect line as necessary
+
+    expect(pascal()).toBe('');
+  });
+  
+  test('Second test description', () => {
+    // Replace this comment with any other necessary code, and update the expect line as necessary
+
+    expect(pascal()).toBe('');
+  });
+});


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
It was decided to add new recursion exercises

**Not to be reviewed until marked as open**

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Adds exercise 19

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Related to [#27265](https://github.com/TheOdinProject/curriculum/issues/27265#issuecomment-2011689860)

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `01_helloWorld: Update test cases`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If this PR includes any changes that affect the solution of an exercise, I've also updated the solution in the `/solutions` folder 