### PR TITLE
02_repeatString - Line-32, replace "odin" with "hey"

### DIFF
--- a/02_repeatString/repeatString.spec.js
+++ b/02_repeatString/repeatString.spec.js
@@ -29,7 +29,7 @@ describe('repeatString', () => {
     /*The .match(/((hey))/g).length is a regex that will count the number of heys
     in the result, which if your function works correctly will equal the number that
     was randomly generated. */
-    expect(repeatString('odin', number).match(/((odin))/g).length).toEqual(number);
+    expect(repeatString('hey', number).match(/((hey))/g).length).toEqual(number);
   });
   test.skip('works with blank strings', () => {
     expect(repeatString('', 10)).toEqual('');


### PR DESCRIPTION
The original code had "hey" as the seed string value and hence the comment on line-29 mentions "hey". But the last commit on the code changed "hey" to "odin".

We can either change instances of comment or the code. I propose changing the code instance from "odin" to "hey" for consistency.

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
There is an inconsistency between the comment on line-29 and its corresponding code on line-32. It provides clarity to the learner by maintaining the same example of "hey" instead of "odin".

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Replaced two instances of "odin" with "hey" on line-32

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #XXXXX

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `01_helloWorld: Update test cases`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If this PR includes any changes that affect the solution of an exercise, I've also updated the solution in the `/solutions` folder 
