### PR TITLE
Add repo-specific CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,9 @@ This contributing guide assumes you have followed the instructions in our genera
 
 ### Adding New Exercises
 
+> [!IMPORTANT]
+> Please do not open a pull request with a new exercise unless you have opened an issue in this repo with your proposal **and** it has been approved by a maintainer.
+
 If a maintainer has approved a new exercise to be added, the new exercise(s) must follow the same format as existing exercises.
 
 To generate a new exercise template, do the following:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# The Odin Project JavaScript Exercises Contributing Guide
+
+Thank you for expressing interest in contributing to The Odin Project (TOP) JavaScript exercises! Before continuing through this guide, be sure you've read our [general contributing guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md), as it contains information that is important for all of our repos.
+
+This contributing guide assumes you have followed the instructions in our general contributing guide to fork and clone our JavaScript exercises repo.
+
+## Table of Contents
+
+- [How to Contribute](#how-to-contribute)
+  - [Prerequisites](#prerequisites)
+  - [Adding New Exercises](#adding-new-exercises)
+
+## How to Contribute
+
+### Prerequisites
+
+- Node v18.0.0 or higher
+- npm v8.5.5 or higher
+
+### Adding New Exercises
+
+If a maintainer has approved a new exercise to be added, the new exercise(s) must follow the same format as existing exercises.
+
+To generate a new exercise template, do the following:
+
+1. Be sure to run `npm install` at the root of the `javascript-exercises` directory to install the necessary dependencies.
+2. Run the command `npm run generate`.
+3. When prompted, enter the name of the new exercise in "camelCase" syntax.
+
+After entering an exercise name, a new directory with the necessary files will be created. You will then need to update the `README.md` and `spec.js` files as well as the files in the `solution` directory of the new exercise.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,6 @@ To generate a new exercise template, do the following:
 
 1. Be sure to run `npm install` at the root of the `javascript-exercises` directory to install the necessary dependencies.
 1. Run the command `npm run generate`.
-1. When prompted, enter the name of the new exercise in "camelCase" syntax.
-
-After entering an exercise name, a new directory with the necessary files will be created. You will then need to update the `README.md` and `spec.js` files as well as the files in the `solution` directory of the new exercise.
+1. When prompted, enter the name of the new exercise in "camelCase" syntax. This will create a new directory with the necessary files included.
+1. Update the `README.md` and `.spec.js` file, as well as the files inside the `solution` directory of the new exercise.
+1. Open a pull request with the new exercise.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ If a maintainer has approved a new exercise to be added, the new exercise(s) mus
 To generate a new exercise template, do the following:
 
 1. Be sure to run `npm install` at the root of the `javascript-exercises` directory to install the necessary dependencies.
-2. Run the command `npm run generate`.
-3. When prompted, enter the name of the new exercise in "camelCase" syntax.
+1. Run the command `npm run generate`.
+1. When prompted, enter the name of the new exercise in "camelCase" syntax.
 
 After entering an exercise name, a new directory with the necessary files will be created. You will then need to update the `README.md` and `spec.js` files as well as the files in the `solution` directory of the new exercise.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ These JavaScript exercises are intended to complement the JavaScript content on 
 
 ## Contributing
 
-If you have a suggestion to improve an exercise, an idea for a new exercise, or notice an issue with an exercise, please feel free to open an issue after thoroughly reading our [contributing guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md).
+If you have a suggestion to improve an exercise, an idea for a new exercise, or notice an issue with an exercise, please feel free to open an issue after thoroughly reading our [contributing guide](https://github.com/TheOdinProject/javascript-exercises/blob/main/CONTRIBUTING.md).
 
 ## How To Use These Exercises
 

--- a/README.md
+++ b/README.md
@@ -38,13 +38,3 @@ The first exercise, `helloWorld`, will walk you through the process in-depth.
 ## Debugging
 
 To debug functions, you can run the tests in the Visual Studio Code debugger terminal. You can open this by clicking the "Run and Debug" icon on the left or pressing <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>D</kbd>, then clicking JavaScript Debug Terminal. You will be able to set breakpoints as you would in the Chrome DevTools debugger. You can run `npm test exerciseName.spec.js` to then execute your code up until your breakpoint and step through your code as necessary. **NOTE**: To take advantage of the debugger, you **MUST** run the script in the debugger terminal, not the bash or zsh terminal.
-
-## Adding a new exercise
-
-To add a new exercise:
-
-1. Be sure to run `npm install` at the root of the `javascript-exercises` directory.
-2. Run the command `npm run generate`.
-3. When prompted, enter the name of the new exercise in "camelCase" syntax.
-
-After entering an exercise name, a new directory with the necessary files will be created. You will then need to update the `README.md` and `spec.js` files as well as the files in the `solution` directory of the new exercise.


### PR DESCRIPTION
## Because

Most of our other repos have their own specific `CONTRIBUTING.md` that extends the general contributing guide.

A surprisingly not-that-uncommon thing I've seen in the community is learners starting these exercises for the first time, following the installation instructions, but then also doing the "Adding New Exercises" instructions at the bottom of the README, even if they're not actually adding any new exercises.

It would make sense to extract that section to a separate contributing guide for this repo, which will keep the README focused on the instructions for installing things and using the exercises, eliminating any accidental `npm run generate`s and all the joy that comes with ensuing confusion.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Writes repo-specific contributing guide.
- Removes "Adding New Exercises" instructions from README.md.
- Changes link to general contributing guide in README.md to point to the repo-specific one (which will open with a link to the general guide, as with other repo-specific guides).


## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #XXXXX

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `01_helloWorld: Update test cases`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If this PR includes any changes that affect the solution of an exercise, I've also updated the solution in the `/solutions` folder 
