### PR TITLE
02_repeatString: Add test preventing use of `String.prototype.repeat`

### DIFF
--- a/02_repeatString/repeatString.spec.js
+++ b/02_repeatString/repeatString.spec.js
@@ -13,6 +13,13 @@ describe('repeatString', () => {
   test.skip('repeats the string 0 times', () => {
     expect(repeatString('bye', 0)).toEqual('');
   });
+  test.skip('does not use the built-in String repeat method', () => {
+    /* Even though there is a built-in String repeat method,
+      in this exercise specifically, we want you to practise using loops */
+    jest.spyOn(String.prototype, 'repeat').mockName('Built-in String repeat method');
+    repeatString("don't use the built-in repeat method!", 1);
+    expect(String.prototype.repeat).not.toHaveBeenCalled();
+  });
   test.skip('returns ERROR with negative numbers', () => {
     expect(repeatString('goodbye', -1)).toEqual('ERROR');
   });

--- a/02_repeatString/solution/repeatString-solution.spec.js
+++ b/02_repeatString/solution/repeatString-solution.spec.js
@@ -13,6 +13,13 @@ describe('repeatString', () => {
   test('repeats the string 0 times', () => {
     expect(repeatString('bye', 0)).toEqual('');
   });
+  test('does not use the built-in String repeat method', () => {
+    /* Even though there is a built-in String repeat method,
+      in this exercise specifically, we want you to practise using loops */
+    jest.spyOn(String.prototype, 'repeat').mockName('Built-in String repeat method');
+    repeatString("don't use the built-in repeat method!", 1);
+    expect(String.prototype.repeat).not.toHaveBeenCalled();
+  });
   test('returns ERROR with negative numbers', () => {
     expect(repeatString('goodbye', -1)).toEqual('ERROR');
   });


### PR DESCRIPTION
## Because

The instructions for 02_repeatString make it clear that the exercise is for practising loops, so the user must not use the built-in `String.prototype.repeat` method to complete this, even if it leads to the same result. Despite this, the test suite doesn't actually prevent its usage. It would be worth adding a single test that fails upon its use and explains why, in order to encourage practising loops.


## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Adds test preventing use of `String.prototype.repeat` in both main and solution test files

## Issue

N/A

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `01_helloWorld: Update test cases`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If this PR includes any changes that affect the solution of an exercise, I've also updated the solution in the `/solutions` folder 
