### PR TITLE
05_sumAll: Fix tests to require correct range summation

### DIFF
--- a/05_sumAll/solution/sumAll-solution.spec.js
+++ b/05_sumAll/solution/sumAll-solution.spec.js
@@ -2,7 +2,7 @@ const sumAll = require('./sumAll-solution');
 
 describe('sumAll', () => {
   test('sums numbers within the range', () => {
-    expect(sumAll(1, 4)).toEqual(10);
+    expect(sumAll(2, 4)).toEqual(9);
   });
   test('works with large numbers', () => {
     expect(sumAll(1, 4000)).toEqual(8002000);

--- a/05_sumAll/sumAll.spec.js
+++ b/05_sumAll/sumAll.spec.js
@@ -2,7 +2,7 @@ const sumAll = require('./sumAll')
 
 describe('sumAll', () => {
   test('sums numbers within the range', () => {
-    expect(sumAll(1, 4)).toEqual(10);
+    expect(sumAll(2, 4)).toEqual(9);
   });
   test.skip('works with large numbers', () => {
     expect(sumAll(1, 4000)).toEqual(8002000);


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
 Improving the tests in javascript-exercises 05 to ensure solutions match expected behavior. Current tests don't require adding numbers between a provided interval, just all the numbers up to the biggest value. This allows incorrect solutions (that don't consider the lower bound if it isn't 1) to pass the tests.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->

- Modifies a test case to use a range with a lower bound other than 1.

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #510  with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/510

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes [#510](https://github.com/TheOdinProject/javascript-exercises/issues/510) 

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `01_helloWorld: Update test cases`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If this PR includes any changes that affect the solution of an exercise, I've also updated the solution in the `/solutions` folder 
