### PR TITLE
Fix typo: change '1 times' to '1 time' in repeatString test

### DIFF
--- a/06_repeatString/repeatString.spec.js
+++ b/06_repeatString/repeatString.spec.js
@@ -7,7 +7,7 @@ describe('repeatString', () => {
   test.skip('repeats the string many times', () => {
     expect(repeatString('hello', 10)).toEqual('hellohellohellohellohellohellohellohellohellohello');
   });
-  test.skip('repeats the string 1 times', () => {
+  test.skip('repeats the string 1 time', () => {
     expect(repeatString('hi', 1)).toEqual('hi');
   });
   test.skip('repeats the string 0 times', () => {


### PR DESCRIPTION
## Because
The test description in `repeatString.spec.js` had a grammatical typo — it said "1 times" instead of the correct singular "1 time". This can cause confusion and reduces clarity in the tests.

## This PR
- Fixes the typo in the test description on line 10 of `repeatString.spec.js`.
- Changes the string from `'repeats the string 1 times'` to `'repeats the string 1 time'`.

## Issue
Closes #546

## Additional Information
This is my first open source contribution, happy to learn and improve!

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `06_repeatString: Fix test description typo`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If this PR includes any changes that affect the solution of an exercise, I've also updated the solution in the `/solutions` folder (if applicable)
