### PR TITLE
fix: correct typo in joinStrings test description

### DIFF
--- a/05_joinStrings/joinStrings-example.spec.js
+++ b/05_joinStrings/joinStrings-example.spec.js
@@ -10,7 +10,7 @@ describe('joinStrings-example', () => {
   test('firstName is Carlos', () => {
     expect(values.firstName).toEqual('Carlos');
   });
-  test('lastName is Carlos', () => {
+  test('lastName is Stevenson', () => {
     expect(values.lastName).toEqual('Stevenson');
   });
   test('greeting is put together correctly', () => {


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
There was a typo in the test description for the joinStrings exercise, which could cause confusion for contributors and learners.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
 - Corrects the test description in 05_joinStrings/joinStrings-example.spec.js from "lastName is Carlos" to "lastName is Stevenson"

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #556

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->
N/A

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `01_helloWorld: Update test cases`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If this PR includes any changes that affect the solution of an exercise, I've also updated the solution in the `/solutions` folder 
