### PR TITLE
added longest sequence array

### DIFF
--- a/17_longestSequence/solution/longestSequence.js
+++ b/17_longestSequence/solution/longestSequence.js
@@ -1,0 +1,24 @@
+function longestConsecutive(nums) {
+  if (nums.length === 0) return 0;
+
+  const numSet = new Set(nums);
+  let longest = 0;
+
+  for (const num of numSet) {
+    if (!numSet.has(num - 1)) {
+      let currentNum = num;
+      let count = 1;
+
+      while (numSet.has(currentNum + 1)) {
+        currentNum++;
+        count++;
+      }
+
+      longest = Math.max(longest, count);
+    }
+  }
+
+  return longest;
+}
+
+module.exports = longestConsecutive;

--- a/17_longestSequence/solution/longestSequence.spec.js
+++ b/17_longestSequence/solution/longestSequence.spec.js
@@ -1,0 +1,73 @@
+const longestConsecutive = require('./longestSequence');
+
+// Helper: returns the actual longest consecutive sequence
+function getLongestSequence(nums) {
+  const numSet = new Set(nums);
+  let longest = 0;
+  let bestSequence = [];
+
+  for (const num of numSet) {
+    if (!numSet.has(num - 1)) {
+      let currentNum = num;
+      let currentSeq = [currentNum];
+
+      while (numSet.has(currentNum + 1)) {
+        currentNum++;
+        currentSeq.push(currentNum);
+      }
+
+      if (currentSeq.length > longest) {
+        longest = currentSeq.length;
+        bestSequence = currentSeq;
+      }
+    }
+  }
+
+  return bestSequence;
+}
+
+// ✅ Tests with printed input, sequence, and output length
+test('should return 4 for [100, 4, 200, 1, 3, 2]', () => {
+  const input = [100, 4, 200, 1, 3, 2];
+  const result = longestConsecutive(input);
+  const sequence = getLongestSequence(input);
+  console.log('Input:', input);
+  console.log('Longest Sequence:', sequence, '| Length:', result);
+  expect(result).toBe(4);
+});
+
+test('should return 8 for [9, 1, 4, 7, 3, 2, 5, 6, 0]', () => {
+  const input = [9, 1, 4, 7, 3, 2, 5, 6, 0];
+  const result = longestConsecutive(input);
+  const sequence = getLongestSequence(input);
+  console.log('Input:', input);
+  console.log('Longest Sequence:', sequence, '| Length:', result);
+  expect(result).toBe(8);
+});
+
+test('should return 5 for [1, 2, 3, 4, 5]', () => {
+  const input = [1, 2, 3, 4, 5];
+  const result = longestConsecutive(input);
+  const sequence = getLongestSequence(input);
+  console.log('Input:', input);
+  console.log('Longest Sequence:', sequence, '| Length:', result);
+  expect(result).toBe(5);
+});
+
+test('should return 1 for [10, 5, 12, 3, 55, 30]', () => {
+  const input = [10, 5, 12, 3, 55, 30];
+  const result = longestConsecutive(input);
+  const sequence = getLongestSequence(input);
+  console.log('Input:', input);
+  console.log('Longest Sequence:', sequence, '| Length:', result);
+  expect(result).toBe(1);
+});
+
+test('should return 0 for []', () => {
+  const input = [];
+  const result = longestConsecutive(input);
+  const sequence = getLongestSequence(input);
+  console.log('Input:', input);
+  console.log('Longest Sequence:', sequence, '| Length:', result);
+  expect(result).toBe(0);
+});


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because

<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->

This PR adds a new JavaScript exercise that challenges students to find the longest consecutive sequence in an unsorted array. It reinforces important concepts like array iteration, use of Sets for efficient lookup, and performance optimization beyond brute-force solutions.

## This PR

<!-- A bullet point list of one or more items describing the specific changes. -->

- Added a new exercise file: `longestSequence.js` containing the function `longestConsecutive()`
- Created a test file: `longestSequence.spec.js` using Jest to validate multiple input cases
- Included logic in tests to print both the length and the actual longest sequence for clarity
- Ensured edge cases such as empty arrays and disjoint inputs are tested

## Issue

<!-- If this PR closes an open issue in this repo, replace the XXXXX below with the issue number. -->

Closes #530 

## Additional Information

<!-- Any other information about this PR, such as a link to a Discord discussion. -->

This challenge helps learners strengthen their understanding of array-based problem-solving and introduces performance-oriented thinking by avoiding brute force and leveraging Sets.

## Pull Request Requirements

<!-- Replace the whitespace between the square brackets with an 'x'. -->

-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `17_longestSequence: Add longest consecutive sequence exercise`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If this PR includes any changes that affect the solution of an exercise, I've also updated the solution in the `/solutions` folder
