### PR TITLE
README: Add disclaimer discouraging solution PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 These JavaScript exercises are intended to complement the JavaScript content on [The Odin Project](https://www.theodinproject.com/) (TOP). They should only be done when instructed during the course of the curriculum.
 
+> [!IMPORTANT]
+> We encourage you to practice your git skills by committing your changes and pushing them to your own fork.  However, please **DO NOT** open a Pull Request to have your solutions merged into this repo or to show your solution.  If we were to merge your changes the exercises would no longer be available as intended for new learners, and opening a PR only causes additional work for us, as we have to close it without merging.
+
 ## Contributing
 
 If you have a suggestion to improve an exercise, an idea for a new exercise, or notice an issue with an exercise, please feel free to open an issue after thoroughly reading our [contributing guide](https://github.com/TheOdinProject/javascript-exercises/blob/main/CONTRIBUTING.md).


### PR DESCRIPTION
## Because
The README needed a clear disclaimer to prevent learners from opening solution pull requests. This helps keep the exercises intact for new students and reduces the maintenance burden on the maintainers.

## This PR
- Added an IMPORTANT disclaimer section to the README explaining that students should not open PRs with their exercise solutions.

## Issue
Closes #380

## Additional Information
N/A

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `01_helloWorld: Update test cases`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If this PR includes any changes that affect the solution of an exercise, I've also updated the solution in the `/solutions` folder 
