### PR TITLE
03_numberChecker/README.md : Sentence correction

### DIFF
--- a/foundations/03_numberChecker/README.md
+++ b/foundations/03_numberChecker/README.md
@@ -4,7 +4,7 @@ Modify the code so it returns `true` when the number is greater than or equal to
 
 Currently, the code returns `true` if the number is `6`, otherwise, it returns `false`.
 
-You may also notice that in this exercise, there are multiple tests (in the file `numberChecker.spec.js`). Only the first test is currently enabled. So after making sure that the first test passes, enable the next one by deleting the `.skip` portion from the `test.skip()` function. It is usually easier if you enable only one test a time, then edit your code so that it passes. You can keep enabling only one at a time until slowly but surely, they all pass!
+You may also notice that in this exercise, there are multiple tests (in the file `numberChecker.spec.js`). Only the first test is currently enabled. So after making sure that the first test passes, enable the next one by deleting the `.skip` portion from the `test.skip()` function. It is usually easier if you enable only one test at a time, then edit your code so that it passes. You can keep enabling only one at a time until slowly but surely, they all pass!
 
 If running `npm test numberChecker.spec.js` returns results similar to what is shown below (showing some tests are skipped), make sure that you have enabled the rest of the tests, as described in the instructions above:
 


### PR DESCRIPTION
Missing 'at' in the following README sentence:

"It is usually easier if you enable only one test a time, then edit your code so that it passes."

Should be: "It is usually easier if you enable only one test at a time, then edit your code so that it passes."

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
The purpose of this PR is to correct a sentence in the 03_numberChecker exercise README.md file.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Changes this sentence in the 2nd paragraph: "It is usually easier if you enable only one test a time, then edit your code so that it passes." --> "It is usually easier if you enable only one test at a time, then edit your code so that it passes."

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Does not close an existing issue.

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `01_helloWorld: Update test cases`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If this PR includes any changes that affect the solution of an exercise, I've also updated the solution in the `/solutions` folder 
